### PR TITLE
Add PostreSQLInstance API backed by CloudSQL

### DIFF
--- a/.up/examples/postgresql.yaml
+++ b/.up/examples/postgresql.yaml
@@ -1,0 +1,9 @@
+apiVersion: database.starter.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: my-db
+spec:
+  parameters:
+    region: east
+    size: small
+    storage: 20

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xpostgresqlinstances.gcp.database.starter.org
+  labels:
+    provider: gcp
+spec:
+  writeConnectionSecretsToNamespace: upbound-system
+  compositeTypeRef:
+    apiVersion: database.starter.org/v1alpha1
+    kind: XPostgreSQLInstance
+  resources:
+    - name: DBInstance
+      base:
+        apiVersion: sql.gcp.upbound.io/v1beta1
+        kind: DatabaseInstance
+        spec:
+          forProvider:
+            databaseVersion: POSTGRES_13
+            deletionProtection: false
+            region: us-west1
+            settings:
+              - diskSize: 20
+                tier: db-f1-micro
+      patches:
+        - fromFieldPath: "metadata.uid"
+          toFieldPath: "spec.writeConnectionSecretToRef.name"
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-postgresql"
+        - fromFieldPath: "spec.parameters.region"
+          toFieldPath: "spec.forProvider.region"
+          transforms:
+          - type: map
+            map:
+              east: us-east1
+              west: us-west1
+        - fromFieldPath: "spec.parameters.size"
+          toFieldPath: "spec.forProvider.settings[0].tier"
+          transforms:
+          - type: map
+            map:
+              small: db-f1-micro
+              medium: db-g1-small
+              large: db-custom-16-61440
+        - fromFieldPath: "spec.parameters.storage"
+          toFieldPath: "spec.forProvider.settings[0].diskSize"
+      connectionDetails:
+        - fromFieldPath: "status.atProvider.publicIpAddress"
+          name: endpoint

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.database.starter.org
+spec:
+  group: database.starter.org
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  claimNames:
+    kind: PostgreSQLInstance
+    plural: postgresqlinstances
+  connectionSecretKeys:
+    - endpoint
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: |
+              The specification for how this PostgreSQLInstance should be
+              deployed.
+            properties:
+              parameters:
+                type: object
+                description: |
+                  The parameters indicating how this PostgreSQLInstance should
+                  be configured.
+                properties:
+                  region:
+                    type: string
+                    enum:
+                      - east
+                      - west
+                    description: |
+                      The geographic region in which this PostgreSQLInstance
+                      should be deployed.
+                  size:
+                    type: string
+                    enum:
+                      - small
+                      - medium
+                      - large
+                    description: |
+                      The machine size for this PostgreSQLInstance.
+                  storage:
+                    type: integer
+                    description: |
+                      The storage size for this PostgreSQLInstance in GB.
+                required:
+                  - region
+                  - size
+                  - storage
+            required:
+              - parameters

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -1,0 +1,22 @@
+apiVersion: meta.pkg.crossplane.io/v1alpha1
+kind: Configuration
+metadata:
+  name: configuration-cloudsql
+  annotations:
+    meta.crossplane.io/maintainer: The Getting Started Organization <support@starter.org>
+    meta.crossplane.io/source: github.com/upbound/configuration-cloudsql
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      This GCP starter configuration offers PostgreSQL as a service backed by
+      CloudSQL.
+    meta.crossplane.io/readme: |
+      This Configuration includes an API that will allow control planes to
+      provision fully configured Google Cloud Platform (GCP) CloudSQL instances,
+      composed using cloud service primitives from the [Upbound Official GCP
+      Provider](https://marketplace.upbound.io/providers/upbound/provider-gcp).
+spec:
+  crossplane:
+    version: ">=v1.7.0-0"
+  dependsOn:
+    - provider: xpkg.upbound.io/upbound/provider-gcp
+      version: ">=v0.27.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a PostreSQLInstance API and an implementation using CloudSQL. Also includes examples.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (configuration-cloudsql) k get claim
NAME         SYNCED   READY   CONNECTION-SECRET   AGE
my-db        True     False   db-conn             19m
my-db-west   True     True    db-conn-west        13m
🤖 (configuration-cloudsql) k get composite
NAME               SYNCED   READY   COMPOSITION                                     AGE
my-db-966pg        True     False   xpostgresqlinstances.gcp.database.starter.org   19m
my-db-west-kr2h9   True     True    xpostgresqlinstances.gcp.database.starter.org   13m
🤖 (configuration-cloudsql) k get databaseinstance
NAME                     READY   SYNCED   EXTERNAL-NAME            AGE
my-db-966pg-xlt2w        False   True     my-db-966pg-xlt2w        19m
my-db-west-kr2h9-gc7ch   True    True     my-db-west-kr2h9-gc7ch   13m
```

Note that the small database actually takes much longer to provision. It did finish eventually though.

```
🤖 (configuration-cloudsql) k get claim
NAME         SYNCED   READY   CONNECTION-SECRET   AGE
my-db        True     True    db-conn             28m
my-db-west   True     True    db-conn-west        22m
🤖 (configuration-cloudsql) k get secrets
NAME           TYPE                                DATA   AGE
db-conn        connection.crossplane.io/v1alpha1   1      4m49s
db-conn-west   connection.crossplane.io/v1alpha1   1      10m
🤖 (configuration-cloudsql) k get composite
NAME               SYNCED   READY   COMPOSITION                                     AGE
my-db-966pg        True     True    xpostgresqlinstances.gcp.database.starter.org   28m
my-db-west-kr2h9   True     True    xpostgresqlinstances.gcp.database.starter.org   23m
🤖 (configuration-cloudsql) k get gcp
NAME                                    AGE
providerconfig.gcp.upbound.io/default   24m

NAME                                                                      AGE   CONFIG-NAME   RESOURCE-KIND      RESOURCE-NAME
providerconfigusage.gcp.upbound.io/271b0a40-d018-4bb1-bc16-67bfd00208a0   24m   default       DatabaseInstance   my-db-966pg-xlt2w
providerconfigusage.gcp.upbound.io/94275e73-67fa-489c-971b-e61dee81d570   23m   default       DatabaseInstance   my-db-west-kr2h9-gc7ch

NAME                                                         READY   SYNCED   EXTERNAL-NAME            AGE
databaseinstance.sql.gcp.upbound.io/my-db-966pg-xlt2w        True    True     my-db-966pg-xlt2w        29m
databaseinstance.sql.gcp.upbound.io/my-db-west-kr2h9-gc7ch   True    True     my-db-west-kr2h9-gc7ch   23m
```