### PR TITLE
Restrict minimum instance size to 10

### DIFF
--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -50,6 +50,7 @@ spec:
                       The machine size for this PostgreSQLInstance.
                   storage:
                     type: integer
+                    minimum: 10
                     description: |
                       The storage size for this PostgreSQLInstance in GB.
                 required:


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a required minimum instance size that matches GCP's requirement.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified minimum instance restriction:
```
🤖 (configuration-cloudsql-1) k apply -f .up/examples/
The PostgreSQLInstance "my-db" is invalid: spec.parameters.storage: Invalid value: 8: spec.parameters.storage in body should be greater than or equal to 10
```